### PR TITLE
fixing deprecated objects and functions in numpy; np.int, np.object

### DIFF
--- a/quspin/basis/basis_1d/base_1d.py
+++ b/quspin/basis/basis_1d/base_1d.py
@@ -151,7 +151,7 @@ class basis_1d(lattice_basis):
 			basis=_np.empty((Ns,),dtype=self._basis_type)
 			self._op = ops_module.t_p_z_op
 
-			if self._basis_type == _np.object:
+			if self._basis_type == object:
 				# if object is basis type then most likely this is for single particle stuff in which case the 
 				# normalizations need to be large ~ 1000 or more which won't fit in int8/int16.
 				N=_np.empty(basis.shape,dtype=_np.int32) 
@@ -177,7 +177,7 @@ class basis_1d(lattice_basis):
 			basis=_np.empty((Ns,),dtype=self._basis_type)
 			self._op = ops_module.t_zA_zB_op
 
-			if self._basis_type == _np.object:
+			if self._basis_type == object:
 				N=_np.empty(basis.shape,dtype=_np.int32) 
 				M=_np.empty(basis.shape,dtype=_np.uint32)
 			else:
@@ -199,7 +199,7 @@ class basis_1d(lattice_basis):
 			basis=_np.empty((Ns,),dtype=self._basis_type)
 			self._op = ops_module.t_pz_op
 
-			if self._basis_type == _np.object:
+			if self._basis_type == object:
 				N=_np.empty(basis.shape,dtype=_np.int32) 
 				M=_np.empty(basis.shape,dtype=_np.uint32)
 			else:			
@@ -221,7 +221,7 @@ class basis_1d(lattice_basis):
 			basis=_np.empty((Ns,),dtype=self._basis_type)
 			self._op = ops_module.t_p_op
 
-			if self._basis_type == _np.object:
+			if self._basis_type == object:
 				N=_np.empty(basis.shape,dtype=_np.int32) 
 				M=_np.empty(basis.shape,dtype=_np.uint32)
 			else:			
@@ -241,7 +241,7 @@ class basis_1d(lattice_basis):
 			basis=_np.empty((Ns,),dtype=self._basis_type)
 			self._op = ops_module.t_z_op
 
-			if self._basis_type == _np.object:
+			if self._basis_type == object:
 				N=_np.empty(basis.shape,dtype=_np.int32) 
 				M=_np.empty(basis.shape,dtype=_np.uint32)
 			else:
@@ -261,7 +261,7 @@ class basis_1d(lattice_basis):
 			basis=_np.empty((Ns,),dtype=self._basis_type)
 			self._op = ops_module.t_zA_op
 
-			if self._basis_type == _np.object:
+			if self._basis_type == object:
 				N=_np.empty(basis.shape,dtype=_np.int32) 
 				M=_np.empty(basis.shape,dtype=_np.uint32)
 			else:			
@@ -281,7 +281,7 @@ class basis_1d(lattice_basis):
 			basis=_np.empty((Ns,),dtype=self._basis_type)
 			self._op = ops_module.t_zB_op
 
-			if self._basis_type == _np.object:
+			if self._basis_type == object:
 				N=_np.empty(basis.shape,dtype=_np.int32) 
 				M=_np.empty(basis.shape,dtype=_np.uint32)
 			else:			
@@ -400,7 +400,7 @@ class basis_1d(lattice_basis):
 			basis=_np.empty((Ns,),dtype=self._basis_type)
 			self._op = ops_module.t_op
 			
-			if self._basis_type == _np.object:
+			if self._basis_type == object:
 				N=_np.empty(basis.shape,dtype=_np.int32) 
 			else:			
 				N=_np.empty(basis.shape,dtype=_np.int8)

--- a/quspin/basis/basis_general/_basis_general_core/general_basis_utils.pyx
+++ b/quspin/basis/basis_general/_basis_general_core/general_basis_utils.pyx
@@ -56,9 +56,9 @@ def basis_int_to_python_int(basis_int):
         raise ValueError("input value must be scalar")
 
     if basis_int_wrapper.dtype in [_np.int32,_np.int64]:
-        basis_int_wrapper = basis_int_wrapper.astype(_np.object)
+        basis_int_wrapper = basis_int_wrapper.astype(object)
 
-    if basis_int_wrapper.dtype == _np.object:
+    if basis_int_wrapper.dtype == object:
         return basis_int
     elif basis_int_wrapper.dtype == uint32:
         return basis_to_python[uint32_t](<uint32_t*>ptr)
@@ -125,12 +125,12 @@ def python_int_to_basis_int(python_int,dtype=None):
         elif nbits <= 16384:
             dtype = uint16384
         else:
-            dtype = _np.object
+            dtype = object
 
     cdef _np.ndarray a_wrapper = _np.empty((),dtype=dtype)
     cdef void * ptr = _np.PyArray_GETPTR1(a_wrapper,0)
 
-    if dtype == _np.object:
+    if dtype == object:
         return python_int
     elif dtype == uint32:
         if nbits > 32:

--- a/quspin/basis/basis_general/base_user.py
+++ b/quspin/basis/basis_general/base_user.py
@@ -107,7 +107,7 @@ def _noncommuting_bits(N,noncommuting_bits):
 		bits = _np.asarray(bits)
 		swap_phase = _np.asarray(swap_phase)
 
-		if not _np.issubdtype(bits.dtype,_np.int):
+		if not _np.issubdtype(bits.dtype,int):
 			raise TypeError("site list most contain only integers.")
 
 		if _np.array(swap_phase).ndim != 0:
@@ -490,8 +490,8 @@ class user_basis(basis_general):
 		self._blocks,map_funcs,pers,qs,map_args = _process_user_blocks(use_32bit,blocks,block_order)
 
 		self.map_funcs = map_funcs
-		self._pers = _np.array(pers,dtype=_np.int)
-		self._qs = _np.array(qs,dtype=_np.int)
+		self._pers = _np.array(pers,dtype=int)
+		self._qs = _np.array(qs,dtype=int)
 		self.map_args = map_args
 		
 


### PR DESCRIPTION
- in more recent numpy > 1.21 versions, some objects are deprecated;

- when a user has the most recent numpy version installed, this downgrades quspin to 0.3.6 which is not waht we want. 

- this pull request fixes the deprecated objects: `_np.object` and `_np.int`. 

- all tests pass on arm-64, py11 (did not test omp version)