### PR TITLE
Get correct matrix exponential for sparse matrices

### DIFF
--- a/quspin/operators/exp_op_core.py
+++ b/quspin/operators/exp_op_core.py
@@ -423,7 +423,7 @@ class exp_op(object):
 		if self.O.is_dense or dense:
 			return _la.expm(self._a * self.O.toarray(**call_kwargs))
 		else:
-			return _la.expm(self._a * self.O.tocsc(**call_kwargs))
+			return _sp.linalg.expm(self._a * self.O.tocsc(**call_kwargs))
 
 	def dot(self, other,shift=None,**call_kwargs):
 		"""Left-multiply operator by matrix exponential.


### PR DESCRIPTION
The method exp_op.get_mat() raised an error for sparse matrices, e.g. the default "dense=False".
As far as I see it, it should be a quick fix using scipy.sparse.linalg to get correct matrix exponential in get_mat() method using the scipy.sparse.linalg.expm() method.