### PR TITLE
Add conversion between state array and basis int

### DIFF
--- a/quspin/tools/__init__.py
+++ b/quspin/tools/__init__.py
@@ -82,6 +82,8 @@ misc
    project_op
    KL_div
    csr_matvec
+   ints_to_array
+   array_to_ints
 
 """
 from . import evolution

--- a/quspin/tools/misc.py
+++ b/quspin/tools/misc.py
@@ -239,7 +239,7 @@ def ints_to_array(basis_ints, N=None):
 
 	The following example shows ...
 	
-	.. literalinclude:: ../../doc_examples/project_op-example.py
+	.. literalinclude:: ../../doc_examples/array_ints_conversion-example.py
 		:linenos:
 		:language: python
 		:lines: 7-
@@ -285,7 +285,7 @@ def array_to_ints(state_array, dtype=None):
 
 	The following example shows ...
 	
-	.. literalinclude:: ../../doc_examples/project_op-example.py
+	.. literalinclude:: ../../doc_examples/array_ints_conversion-example.py
 		:linenos:
 		:language: python
 		:lines: 7-

--- a/quspin/tools/misc.py
+++ b/quspin/tools/misc.py
@@ -11,6 +11,8 @@ from .expm_multiply_parallel_core import csr_matvec
 
 from .matvec.matvec_core import matvec, get_matvec_function
 
+from ..basis import get_basis_type
+
 import warnings
 
 __all__ =  ["project_op", 
@@ -18,6 +20,8 @@ __all__ =  ["project_op",
 			"mean_level_spacing",
 			"matvec",
 			"get_matvec_function",
+			"ints_to_array",
+			"array_to_ints",
 			]
 
 def project_op(Obs,proj,dtype=_np.complex128):
@@ -223,5 +227,97 @@ def mean_level_spacing(E,verbose=True):
 		return _np.mean(_np.divide( aux.min(1), aux.max(1) )[0:-1] )
 
 	
+def ints_to_array(basis_ints, N=None):
+    """Converts QuSpin basis type integers to a state array with binary elements.
+
+	This function takes an array of batched QuSpin basis type integers and converts it
+    to a batched state array with 0/1 elements representing spin-down/up or 0/1 occupation.
+    Conversion to higher spins or larger occupation numbers is not yet implemented.
+
+	Examples
+	--------
+
+	The following example shows ...
+	
+	.. literalinclude:: ../../doc_examples/project_op-example.py
+		:linenos:
+		:language: python
+		:lines: 7-
+
+	Parameters
+	-----------
+	basis_ints: np.ndarray(int)
+        batched integers to be converted
+		
+	N: int, optional
+		number of sites (doubled for spinful fermions), default to be the biggest size
+        represented by `basis_ints.dtype`.
+
+	Returns
+	-------- 
+	state_array: np.ndarray(np.uint8)
+        batched state array with binary entries
+	"""
+
+    basis_ints = _np.asarray(basis_ints, order="C").reshape(-1, 1)
+    
+    if not basis_ints.dtype.isbuiltin:
+        basis_ints = basis_ints.view(_np.uint64)
+        valid = basis_ints[:, -2:-1]
+        basis_ints = _np.ascontiguousarray(basis_ints[:, :-2])
+        idx = _np.arange(basis_ints.shape[1], dtype=_np.uint8)
+        idx = _np.broadcast_to(idx, basis_ints.shape)
+        basis_ints[idx >= valid] = 0
+    basis_ints = basis_ints.view(_np.uint8)
+    state_array = _np.unpackbits(basis_ints, axis=1, count=N, bitorder="little")
+    return state_array[:, ::-1]
 
 
+def array_to_ints(state_array, dtype=None):
+    """Converts a state array with binary elements to QuSpin basis type integers.
+
+	This function takes a batched state array with 0/1 elements and converts it
+    to an array of batched QuSpin basis type integers.
+    Conversion of higher spins or larger occupation numbers is not yet implemented.
+
+	Examples
+	--------
+
+	The following example shows ...
+	
+	.. literalinclude:: ../../doc_examples/project_op-example.py
+		:linenos:
+		:language: python
+		:lines: 7-
+
+	Parameters
+	-----------
+	state_array: np.ndarray(np.uint8)
+        batched state array to be converted
+		
+	dtype: dtype, optional
+		data type used for the basis integers, default to be the type expressing the 
+        state with smallest size
+
+	Returns
+	-------- 
+	basis_ints: np.ndarray(int)
+        batched basis integers
+	"""
+
+    state_array = _np.atleast_2d(state_array)
+    nbits = state_array.shape[1]
+    if dtype is None:
+        dtype = get_basis_type(nbits, None, 2)
+    dtype = _np.dtype(dtype)
+    nfull = dtype.itemsize * 8
+    
+    pads = _np.zeros((state_array.shape[0], nfull - nbits), state_array.dtype)
+    state_array = _np.concatenate([pads, state_array], axis=1)
+    state_array = _np.ascontiguousarray(state_array[:, ::-1], dtype=_np.uint8)
+    basis_ints = _np.packbits(state_array, axis=1, bitorder="little")
+    if not dtype.isbuiltin:
+        valid = _np.array([(nbits - 1) // 64 + 1], _np.uint64).view(_np.uint8)
+        basis_ints[:, -16:-8] = valid
+    basis_ints = basis_ints.view(dtype)
+    return basis_ints

--- a/sphinx/doc_examples/array_ints_conversion-example.py
+++ b/sphinx/doc_examples/array_ints_conversion-example.py
@@ -1,0 +1,24 @@
+import numpy as np
+from quspin.basis import spin_basis_general
+from quspin.tools.misc import ints_to_array, array_to_ints
+
+N = 10
+basis = spin_basis_general(N, make_basis=False)
+
+# initial states
+num_states = 2
+state_array = np.random.randint(0, 2, (num_states, N), dtype=np.uint8)
+print(f"The {num_states} initial states are")
+print(state_array)
+
+# convert state array to basis integers
+basis_ints = array_to_ints(state_array, basis.dtype)
+
+# apply Sx on site 4
+ME, bra, ket = basis.Op_bra_ket("x", [4], 1., np.float64, basis_ints)
+
+# convert outcome back to state array
+bra_array = ints_to_array(bra, N)
+
+print("Applying Sx on site 4, the new states are")
+print(bra_array)

--- a/sphinx/doc_examples/array_ints_conversion-example.py
+++ b/sphinx/doc_examples/array_ints_conversion-example.py
@@ -1,3 +1,9 @@
+from __future__ import print_function, division
+#
+import sys,os
+quspin_path = os.path.join(os.getcwd(),"../../")
+sys.path.insert(0,quspin_path)
+#
 import numpy as np
 from quspin.basis import spin_basis_general
 from quspin.tools.misc import ints_to_array, array_to_ints

--- a/tests/array_ints_conversion_test.py
+++ b/tests/array_ints_conversion_test.py
@@ -1,0 +1,24 @@
+# import sys,os
+# qspin_path = os.path.join(os.getcwd(),"../")
+# sys.path.insert(0,qspin_path)
+
+import numpy as np
+import quspin
+from quspin.basis import spin_basis_general
+from quspin.tools.misc import ints_to_array, array_to_ints
+
+N = 100
+ints_dtype = None
+
+state_array = np.random.randint(0, 2, (1000, N))
+ints = array_to_ints(state_array, ints_dtype)
+new_array = ints_to_array(ints, N)
+assert np.all(state_array == new_array)
+
+N = 50
+basis = spin_basis_general(N, make_basis=False)
+basis_int = np.random.randint(0, 1 << 50, dtype=basis.dtype)
+state_string = basis.int_to_state(basis_int)
+state_from_string = np.fromstring(state_string[1:-1], dtype=np.uint8, sep=' ')
+state_array = ints_to_array(basis_int, N).flatten()
+assert np.all(state_from_string == state_array)


### PR DESCRIPTION
In `quspin.tools.misc`, two functions `array_to_ints` and `ints_to_array` are added for batched conversion between state array and basis integers.

For instance
state array 0101 <-> basis integer 5

Compared with the existing functions `state_to_int` and `int_to_state`, the new conversion in addition:

1. Provides efficient batch conversion
2. Expresses the state as numpy array instead of string